### PR TITLE
remove python-home

### DIFF
--- a/config/apache-default.conf
+++ b/config/apache-default.conf
@@ -11,7 +11,7 @@
         </Directory>
 
         WSGIDaemonProcess rdmo user=rdmo group=rdmo \
-            home=/srv/rdmo/rdmo-app python-home=/srv/rdmo/rdmo-app/env
+            home=/srv/rdmo/rdmo-app
         WSGIProcessGroup rdmo
         WSGIScriptAlias / /srv/rdmo/rdmo-app/config/wsgi.py process-group=rdmo
 


### PR DESCRIPTION
directory does not exist, is not created anywhere, and is not used. But makes problems with Ubuntu 18.04.